### PR TITLE
AE-1372: Adding validateConfig function to transaction-failure-count bot template

### DIFF
--- a/examples/transaction-failure-count-bot-config.json
+++ b/examples/transaction-failure-count-bot-config.json
@@ -7,13 +7,11 @@
       "botType": "transaction-failure-count",
       "name": "bot_10",
       "contracts": {
-        "failedTransactions": {
-          "1Inch": {
-            "address": "0x1111111254fb6c44bAC0beD2854e76F90643097d",
-            "transactionFailuresLimit": 0,
-            "type": "Info",
-            "severity": "Info"
-          }
+        "1Inch": {
+          "address": "0x1111111254fb6c44bAC0beD2854e76F90643097d",
+          "transactionFailuresLimit": 0,
+          "type": "Info",
+          "severity": "Info"
         }
       },
       "blockWindow": 25

--- a/src/transaction-failure-count/SETUP.md
+++ b/src/transaction-failure-count/SETUP.md
@@ -9,19 +9,19 @@ to add/remove/update contracts in the bot configuration file.
 1. `blockWindow` (required) - The Integer value for this key corresponds to how long failed
 transactions should be counted against a contract's failed transactions limit before being removed.
 
-2.  `failedTransactions` (required) - The Object value for this key corresponds to contracts that we
+2.  `contracts` (required) - The Object value for this key corresponds to contracts that we
 want to monitor the number of failed transactions for. Each key in the Object is a contract name that
 we can specify, where that name is simply a string that we use as a label when referring to the contract
 (the string can be any valid string that we choose, it will not affect the monitoring by the bot).
 The Object corresponding to each contract name requires an address key/value pair, a key/value pair
-for the limit of failed transctions allowed, a Finding type key/value pair, and a Finding severity
+for the limit of failed transactions allowed, a Finding type key/value pair, and a Finding severity
 key/value pair (Note that using a Finding type and/or Finding severity that is not listed in the Forta SDK
 will cause the bot to throw an error). For example, to monitor the Uniswap V3 Factory for failed transactions, we would need
 the contract address, the number of failed transactions that are allowed to occur before an alert is
 generated, and a type and severity for the alert:
 
 ```
-  "failedTransactions": {
+  "contracts": {
     "UniswapV3Factory": {
       "address": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
       "transactionFailuresLimit": 2,


### PR DESCRIPTION
The `transaction-failure-count` bot template did not have a `validateConfig` function.  This work added one and also simplified the configuration file format to remove the unnecessary `failedTransactions` key from the corresponding configuration file.

A separate ticket will be created to further clean up other configuration files.